### PR TITLE
Added try block to handle error on jQuery Mobile 1.9

### DIFF
--- a/jquery.awesomeCloud-0.2.js
+++ b/jquery.awesomeCloud-0.2.js
@@ -683,14 +683,18 @@ Extra Thanks:
 			return output;
 		},
 		updateGrid: function (gx, gy, gw, gh, skipDiffChannel) {
-			var x = gw, y, imgData = this.ctx.getImageData(gx * this.settings.gridSize, gy * this.settings.gridSize, gw * this.settings.gridSize, gh * this.settings.gridSize);
-			while (x--) {
-				y = gh;
-				while (y--) {
-					if (!this.isGridEmpty(imgData, x * this.settings.gridSize, y * this.settings.gridSize, gw * this.settings.gridSize, gh * this.settings.gridSize, skipDiffChannel)) {
-						this.grid[ gx + x ][ gy + y ] = false;
+			try {
+				var x = gw, y, imgData = this.ctx.getImageData(gx * this.settings.gridSize, gy * this.settings.gridSize, gw * this.settings.gridSize, gh * this.settings.gridSize);
+				while (x--) {
+					y = gh;
+					while (y--) {
+						if (!this.isGridEmpty(imgData, x * this.settings.gridSize, y * this.settings.gridSize, gw * this.settings.gridSize, gh * this.settings.gridSize, skipDiffChannel)) {
+							this.grid[ gx + x ][ gy + y ] = false;
+						}
 					}
-				}
+				}				
+			} catch(e) {
+				return
 			}
 		},
 		isGridEmpty: function (imgData, x, y, w, h, skipDiffChannel) {


### PR DESCRIPTION
On jQuery Mobile 1.9, when you navigate away from a page that has a canvas on it to a page that does not, you get an error regarding getImageData. This try block resolves the problem. I do not have a comprehensive set of tests to run it against, so I offer you this in case it helps.
